### PR TITLE
Fix: resolve 6 critical vulnerabilities

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -377,10 +377,12 @@ func (b *BlockChain) removeOrphanBlockAbe(orphan *orphanBlockAbe) {
 // blocks and will remove the oldest received orphan block if the limit is
 // exceeded.
 func (b *BlockChain) addOrphanBlock(block *abeutil.BlockAbe) {
-	// Remove expired orphan blocks.
+	// Collect expired orphan blocks under the lock.
+	b.orphanLock.Lock()
+	var expired []*orphanBlockAbe
 	for _, oBlock := range b.orphansAbe {
 		if time.Now().After(oBlock.expiration) {
-			b.removeOrphanBlockAbe(oBlock)
+			expired = append(expired, oBlock)
 			continue
 		}
 
@@ -390,19 +392,21 @@ func (b *BlockChain) addOrphanBlock(block *abeutil.BlockAbe) {
 			b.oldestOrphanAbe = oBlock
 		}
 	}
+	b.orphanLock.Unlock()
 
-	// Limit orphan blocks to prevent memory exhaustion.
-	if len(b.orphansAbe)+1 > MaxOrphanBlocks {
-		// Remove the oldest orphan to make room for the new one.
-		b.removeOrphanBlockAbe(b.oldestOrphanAbe)
-		b.oldestOrphanAbe = nil
+	// Remove expired orphans outside the lock (removeOrphanBlockAbe locks internally).
+	for _, oBlock := range expired {
+		b.removeOrphanBlockAbe(oBlock)
 	}
 
-	// Protect concurrent access.  This is intentionally done here instead
-	// of near the top since removeOrphanBlock does its own locking and
-	// the range iterator is not invalidated by removing map entries.
+	// Limit orphan blocks to prevent memory exhaustion.
 	b.orphanLock.Lock()
-	defer b.orphanLock.Unlock()
+	if len(b.orphansAbe)+1 > MaxOrphanBlocks {
+		if b.oldestOrphanAbe != nil {
+			b.removeOrphanBlockAbe(b.oldestOrphanAbe)
+		}
+		b.oldestOrphanAbe = nil
+	}
 
 	// Insert the block into the orphan map with an expiration time
 	// 1 hour from now.
@@ -416,6 +420,7 @@ func (b *BlockChain) addOrphanBlock(block *abeutil.BlockAbe) {
 	// Add to previous hash lookup index for faster dependency lookups.
 	prevHash := &block.MsgBlock().Header.PrevBlock
 	b.prevOrphansAbe[*prevHash] = append(b.prevOrphansAbe[*prevHash], oBlock)
+	b.orphanLock.Unlock()
 }
 
 // SequenceLock represents the converted relative lock-time in seconds, and

--- a/blockchain/scriptval.go
+++ b/blockchain/scriptval.go
@@ -140,7 +140,7 @@ func newTxValidator(utxoRingView *UtxoRingViewpoint, autView *CTAUTViewpoint, wi
 // which is dedicated to valid AutWitness, bu calling crypto-layer.
 func ValidateTransactionScriptsAbe(tx *abeutil.TxAbe, utxoRingView *UtxoRingViewpoint, autView *CTAUTViewpoint, witnessCache *txscript.WitnessCache) error {
 	// If transaction witness has already been validated and stored in cache, just return.
-	if witnessCache.Exists(*tx.Hash()) {
+	if witnessCache.Exists(*tx.Hash(), *tx.TxWitnessHash()) {
 		return nil
 	}
 
@@ -205,7 +205,7 @@ func ValidateTransactionScriptsAbe(tx *abeutil.TxAbe, utxoRingView *UtxoRingView
 	}
 
 	// Add transaction into witness cache.
-	witnessCache.Add(*tx.Hash())
+	witnessCache.Add(*tx.Hash(), *tx.TxWitnessHash())
 	return nil
 }
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -434,7 +434,7 @@ func (mp *TxPool) limitNumOrphansAbe() error {
 
 	// Nothing to do if adding another orphan will not cause the pool to
 	// exceed the limit.
-	if len(mp.orphans)+1 <= mp.cfg.Policy.MaxOrphanTxs {
+	if len(mp.orphansAbe)+1 <= mp.cfg.Policy.MaxOrphanTxs {
 		return nil
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -15,6 +15,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -5403,6 +5404,17 @@ func (s *rpcServer) Start() {
 		if err != nil {
 			jsonAuthFail(w)
 			return
+		}
+
+		// Reject cross-origin WebSocket requests to prevent CSWSH attacks.
+		origin := r.Header.Get("Origin")
+		if origin != "" {
+			originURL, err := url.Parse(origin)
+			if err != nil || originURL.Host != r.Host {
+				rpcsLog.Warnf("Rejected WebSocket connection from origin %s (host %s)", origin, r.Host)
+				http.Error(w, "403 Forbidden", http.StatusForbidden)
+				return
+			}
 		}
 
 		// Attempt to upgrade the connection to a websocket connection

--- a/txscript/hashcache.go
+++ b/txscript/hashcache.go
@@ -33,7 +33,8 @@ func NewTxSigHashes(tx *wire.MsgTx) *TxSigHashes {
 // multiple goroutines can safely re-use the pre-computed partial sighashes
 // speeding up validation time amongst all inputs found within a block.
 type HashCache struct {
-	sigHashes map[chainhash.Hash]*TxSigHashes
+	sigHashes  map[chainhash.Hash]*TxSigHashes
+	maxEntries uint
 
 	sync.RWMutex
 }
@@ -42,7 +43,8 @@ type HashCache struct {
 // of entries which may exist within it at anytime.
 func NewHashCache(maxSize uint) *HashCache {
 	return &HashCache{
-		sigHashes: make(map[chainhash.Hash]*TxSigHashes, maxSize),
+		sigHashes:  make(map[chainhash.Hash]*TxSigHashes, maxSize),
+		maxEntries: maxSize,
 	}
 }
 
@@ -50,8 +52,15 @@ func NewHashCache(maxSize uint) *HashCache {
 // transaction.
 func (h *HashCache) AddSigHashes(tx *wire.MsgTx) {
 	h.Lock()
+	defer h.Unlock()
+
+	if h.maxEntries > 0 && uint(len(h.sigHashes)) >= h.maxEntries {
+		for sigHash := range h.sigHashes {
+			delete(h.sigHashes, sigHash)
+			break
+		}
+	}
 	h.sigHashes[tx.TxHash()] = NewTxSigHashes(tx)
-	h.Unlock()
 }
 
 // ContainsHashes returns true if the partial sighashes for the passed

--- a/txscript/witnesscache.go
+++ b/txscript/witnesscache.go
@@ -6,14 +6,18 @@ import (
 	"github.com/pqabelian/abec/chainhash"
 )
 
+type witnessCacheKey struct {
+	txHash      chainhash.Hash
+	witnessHash chainhash.Hash
+}
+
 // WitnessCache implements a transaction witness verification cache with a randomized
 // entry eviction policy. Only valid transactions will be added to the cache.
 // It can speed up the validation of transactions within a block,
 // if they've already been seen and verified within the mempool.
-// TODO use (tx_hash,witness_hash)?
 type WitnessCache struct {
 	sync.RWMutex
-	validTransactions map[chainhash.Hash]struct{}
+	validTransactions map[witnessCacheKey]struct{}
 	maxEntries        uint
 }
 
@@ -24,7 +28,7 @@ type WitnessCache struct {
 // cache to exceed the max.
 func NewWitnessCache(maxEntries uint) *WitnessCache {
 	return &WitnessCache{
-		validTransactions: make(map[chainhash.Hash]struct{}, maxEntries),
+		validTransactions: make(map[witnessCacheKey]struct{}, maxEntries),
 		maxEntries:        maxEntries,
 	}
 }
@@ -34,9 +38,9 @@ func NewWitnessCache(maxEntries uint) *WitnessCache {
 //
 // NOTE: This function is safe for concurrent access. Readers won't be blocked
 // unless there exists a writer, adding an entry to the WitnessCache.
-func (s *WitnessCache) Exists(txHash chainhash.Hash) bool {
+func (s *WitnessCache) Exists(txHash chainhash.Hash, witnessHash chainhash.Hash) bool {
 	s.RLock()
-	_, ok := s.validTransactions[txHash]
+	_, ok := s.validTransactions[witnessCacheKey{txHash: txHash, witnessHash: witnessHash}]
 	s.RUnlock()
 
 	return ok
@@ -48,7 +52,7 @@ func (s *WitnessCache) Exists(txHash chainhash.Hash) bool {
 //
 // NOTE: This function is safe for concurrent access. Writers will block
 // simultaneous readers until function execution has concluded.
-func (s *WitnessCache) Add(txHash chainhash.Hash) {
+func (s *WitnessCache) Add(txHash chainhash.Hash, witnessHash chainhash.Hash) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -65,5 +69,5 @@ func (s *WitnessCache) Add(txHash chainhash.Hash) {
 			break
 		}
 	}
-	s.validTransactions[txHash] = struct{}{}
+	s.validTransactions[witnessCacheKey{txHash: txHash, witnessHash: witnessHash}] = struct{}{}
 }

--- a/wire/message.go
+++ b/wire/message.go
@@ -24,6 +24,10 @@ const CommandSize = 12
 // and corresponding, the max message size is adjusted to 320MB for redundancy
 const MaxMessagePayload = 320 * 1024 * 1024 // 256MB
 
+// maxReadAlloc is the maximum bytes allocated for reading a single message
+// payload, to prevent memory exhaustion from oversized message headers.
+const maxReadAlloc = 32 * 1024 * 1024 // 32MB
+
 // Commands used in bitcoin message headers which describe the type of message.
 const (
 	CmdVersion       = "version"
@@ -417,6 +421,14 @@ func ReadMessageWithEncodingN(r io.Reader, pver uint32, btcnet AbelianNet,
 		str := fmt.Sprintf("payload exceeds max length - header "+
 			"indicates %v bytes, but max payload size for "+
 			"messages of type [%v] is %v.", hdr.length, command, mpl)
+		return totalBytes, nil, nil, messageError("ReadMessage", str)
+	}
+
+	// Cap pre-allocation to prevent memory exhaustion.
+	if hdr.length > maxReadAlloc {
+		discardInput(r, hdr.length)
+		str := fmt.Sprintf("payload length %v exceeds max read alloc %v",
+			hdr.length, maxReadAlloc)
 		return totalBytes, nil, nil, messageError("ReadMessage", str)
 	}
 


### PR DESCRIPTION
C1 — Mempool orphan pool size check uses wrong map mempool/mempool.go:437 was checking len(mp.orphans) (the old btcd orphan pool) instead of len(mp.orphansAbe) when deciding whether to evict Abe orphans. Since the old pool is always empty, the Abe orphan pool grew without bound, allowing an attacker to exhaust node memory by feeding un-relatable transactions.

C2 — Data race on orphan block map causes crashes blockchain/chain.go:381 iterated b.orphansAbe without holding orphanLock, while concurrent ProcessBlockAbe calls could write to the same map. This caused panics from concurrent map read/write under load. The fix acquires the lock before iteration, collects expired orphans, then removes them outside the lock to avoid deadlock with removeOrphanBlockAbe.

C3 — HashCache grows without eviction txscript/hashcache.go:51 accepted a maxSize parameter but only used it as the initial map capacity — entries were never evicted. The map grew forever during block processing. Added maxEntries enforcement with random eviction matching the existing SigCache pattern.

C4 — WitnessCache key ignores witness data txscript/witnesscache.go:13 keyed entries only by txHash (which excludes witness). Two transactions with identical inputs/outputs but different witnesses would collide, causing the second to skip verification. Changed the key to a (txHash, witnessHash) struct and updated callers in blockchain/scriptval.go.

C5 — Network message reader allocates 256MB per message wire/message.go:424 allocated make([]byte, hdr.length) using the header-declared length (up to 256MB for block messages) before verifying checksum or deserializing. An attacker could send a crafted header to force a 256MB heap allocation. Added maxReadAlloc (32MB) as a hard cap with early rejection.

C6 — WebSocket endpoint allows cross-origin hijacking rpcserver.go:5410 used websocket.Upgrade with the default CheckOrigin (accepts all origins). An authenticated user visiting a malicious site could have RPC commands executed against their node. Added same-origin enforcement by comparing Origin header against Host.